### PR TITLE
機能 2: 災害Eventページに登録日時とタイトル追加

### DIFF
--- a/database/migrations/2022_06_23_113547_add_title_to_site_urls_table.php
+++ b/database/migrations/2022_06_23_113547_add_title_to_site_urls_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddTitleToSiteUrlsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('site_urls', function (Blueprint $table) {
+            $table->text('title');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('site_urls', function (Blueprint $table) {
+            $table->dropColumn('title');
+        });
+    }
+}

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -16143,3 +16143,7 @@ body#event-about {
     padding-top: 85px;
   }
 }
+
+.registration_date {
+  float: right;
+}

--- a/resources/views/event/show.blade.php
+++ b/resources/views/event/show.blade.php
@@ -25,7 +25,8 @@
             <ul class="list-group list-group-flush">
                 @forelse ($emergencyEvent->siteUrls->sortByDesc('registration_date') as $siteUrl)
                     <li class="list-group-item">
-                        <a href="{{ $siteUrl->url }}" class="text-secondary">{{ $siteUrl->url }}</a>
+                        <a href="{{ $siteUrl->url }}" class="text-secondary">@if(empty($siteUrl->title)) {{ $siteUrl->url }} @else {{ $siteUrl->title }} @endif</a>
+                        <a class="text-secondary registration_date">{{ $siteUrl->registration_date }}</a>
                     </li>
                 @empty
                     <li class="list-group-item">


### PR DESCRIPTION
site_urlsテーブルにタイトルを格納するカラムを追加するマイグレーションファイルを追加しています。
災害イベントページでは、タイトルが追加されている場合はタイトルを表示しており（タイトルをクリックするとURLに飛べる仕様）、追加されていない場合はURLをそのまま表示しています。